### PR TITLE
Remove unused meta file

### DIFF
--- a/Assets/Scenes.meta
+++ b/Assets/Scenes.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: b06ec70448d7a6d438526f3b612ff299
-folderAsset: yes
-timeCreated: 1469265025
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Unity actually deletes it and triggers a warning